### PR TITLE
Fix pipefail

### DIFF
--- a/egs/arctic/voc1/run.sh
+++ b/egs/arctic/voc1/run.sh
@@ -134,7 +134,8 @@ fi
 
 if [ "${stage}" -le 3 ] && [ "${stop_stage}" -ge 3 ]; then
     echo "Stage 3: Network decoding"
-    [ -z "${checkpoint}" ] && checkpoint="$(find "${expdir}" -name "*.pkl" -print0 | xargs -0 ls -t | head -n 1)"
+    # shellcheck disable=SC2012
+    [ -z "${checkpoint}" ] && checkpoint="$(ls -dt "${expdir}"/*.pkl | head -1 || true)"
     outdir="${expdir}/wav/$(basename "${checkpoint}" .pkl)"
     pids=()
     for name in "${dev_set}" "${eval_set}"; do

--- a/egs/csmsc/voc1/run.sh
+++ b/egs/csmsc/voc1/run.sh
@@ -131,7 +131,8 @@ fi
 
 if [ "${stage}" -le 3 ] && [ "${stop_stage}" -ge 3 ]; then
     echo "Stage 3: Network decoding"
-    [ -z "${checkpoint}" ] && checkpoint="$(find "${expdir}" -name "*.pkl" -print0 | xargs -0 ls -t | head -n 1)"
+    # shellcheck disable=SC2012
+    [ -z "${checkpoint}" ] && checkpoint="$(ls -dt "${expdir}"/*.pkl | head -1 || true)"
     outdir="${expdir}/wav/$(basename "${checkpoint}" .pkl)"
     pids=()
     for name in "${dev_set}" "${eval_set}"; do

--- a/egs/jsut/voc1/run.sh
+++ b/egs/jsut/voc1/run.sh
@@ -131,7 +131,8 @@ fi
 
 if [ "${stage}" -le 3 ] && [ "${stop_stage}" -ge 3 ]; then
     echo "Stage 3: Network decoding"
-    [ -z "${checkpoint}" ] && checkpoint="$(find "${expdir}" -name "*.pkl" -print0 | xargs -0 ls -t | head -n 1)"
+    # shellcheck disable=SC2012
+    [ -z "${checkpoint}" ] && checkpoint="$(ls -dt "${expdir}"/*.pkl | head -1 || true)"
     outdir="${expdir}/wav/$(basename "${checkpoint}" .pkl)"
     pids=()
     for name in "${dev_set}" "${eval_set}"; do

--- a/egs/ljspeech/voc1/run.sh
+++ b/egs/ljspeech/voc1/run.sh
@@ -130,7 +130,8 @@ fi
 
 if [ "${stage}" -le 3 ] && [ "${stop_stage}" -ge 3 ]; then
     echo "Stage 3: Network decoding"
-    [ -z "${checkpoint}" ] && checkpoint="$(find "${expdir}" -name "*.pkl" -print0 | xargs -0 ls -t | head -n 1)"
+    # shellcheck disable=SC2012
+    [ -z "${checkpoint}" ] && checkpoint="$(ls -dt "${expdir}"/*.pkl | head -1 || true)"
     outdir="${expdir}/wav/$(basename "${checkpoint}" .pkl)"
     pids=()
     for name in "${dev_set}" "${eval_set}"; do


### PR DESCRIPTION
`find | xargs | head` causes `SIGPIPE` and stop later processings when using `set -o pipefail`.
Putting `|| true` can avoid this issue.

Reference: https://qiita.com/progrhyme/items/6e522d83de3c94aadec9