### PR TITLE
Bump librosa version to 0.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ requirements = {
     "install": [
         "torch>=1.0.1",
         "setuptools>=38.5.1",
-        "librosa>=0.7.0",
+        "librosa>=0.8.0",
         "soundfile>=0.10.2",
         "tensorboardX>=1.8",
         "matplotlib>=3.1.0",
@@ -33,8 +33,7 @@ requirements = {
         "kaldiio>=2.14.1",
         "h5py>=2.9.0",
         "yq>=2.10.0",
-        # Fix No module named "numba.decorators"
-        "numba<=0.48",
+        "numba>=0.50",
         "gdown",
     ],
     "setup": [

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ requirements = {
         "kaldiio>=2.14.1",
         "h5py>=2.9.0",
         "yq>=2.10.0",
-        "numba>=0.50",
         "gdown",
     ],
     "setup": [


### PR DESCRIPTION
Hello :) 

I'd like to avoid the upper version bound for numba and so I made this PR. If I read the librosa's changelog correctly, this should be backward compatible. https://librosa.org/doc/latest/changelog.html

Note that v0.8.0 changed the normalization method for `librosa.filters.mel` but it should be okay if we don't use `norm=p` (p in numbers) explicitly (ref: https://github.com/librosa/librosa/pull/1050; now default is `slaney`).