### PR TITLE
add tag_or_url for download_pretrained_model

### DIFF
--- a/parallel_wavegan/utils/utils.py
+++ b/parallel_wavegan/utils/utils.py
@@ -370,9 +370,21 @@ def download_pretrained_model(tag_or_url, download_dir=None):
     Returns:
         str: Path of downloaded model checkpoint.
 
-    Example:
-        from parallel_wavegan.utils import download_pretrained_model
-        download_path = download_pretrained_model("https://drive.google.com/file/d/10GYvB_mIKzXzSjD67tSnBhknZRoBjsNb/")
+    Examples:
+        # Download by specifying tag
+        >>> from parallel_wavegan.utils import download_pretrained_model
+        >>> tag = "ljspeech_parallel_wavegan.v1"
+        >>> download_path = download_pretrained_model(tag)
+
+        # Download by specifying URL
+        >>> from parallel_wavegan.utils import download_pretrained_model
+        >>> url = "https://drive.google.com/file/d/10GYvB_mIKzXzSjD67tSnBhknZRoBjsNb"
+        >>> download_path = download_pretrained_model(url)
+
+        # The following URL also works
+        >>> url = "https://drive.google.com/file/d/10GYvB_mIKzXzSjD67tSnBhknZRoBjsNb/view?usp=sharing"
+        >>> download_path = download_pretrained_model(url)
+
     """
     if download_dir is None:
         download_dir = os.path.expanduser("~/.cache/parallel_wavegan")
@@ -382,7 +394,9 @@ def download_pretrained_model(tag_or_url, download_dir=None):
         tag = tag_or_url
     else:
         # get google drive id from the url link
-        assert "drive.google.com" in tag_or_url, "Unknown URL format. Please use google drive for the model"
+        assert (
+            "drive.google.com" in tag_or_url
+        ), "Unknown URL format. Please use google drive for the model."
         p = re.compile(r"/[-\w]{25,}")
         id_ = p.findall(tag_or_url)[0][1:]
         tag = id_

--- a/parallel_wavegan/utils/utils.py
+++ b/parallel_wavegan/utils/utils.py
@@ -364,23 +364,28 @@ def download_pretrained_model(tag_or_url, download_dir=None):
     """Download pretrained model form google drive.
 
     Args:
-        tag (str): Pretrained model tag.
+        tag_or_url (str): Pretrained model tag or the google drive url for the model.
         download_dir (str): Directory to save downloaded files.
 
     Returns:
         str: Path of downloaded model checkpoint.
 
+    Example:
+        from parallel_wavegan.utils import download_pretrained_model
+        download_path = download_pretrained_model("https://drive.google.com/file/d/10GYvB_mIKzXzSjD67tSnBhknZRoBjsNb/")
     """
     if download_dir is None:
         download_dir = os.path.expanduser("~/.cache/parallel_wavegan")
     if tag_or_url in PRETRAINED_MODEL_LIST:
         id_ = PRETRAINED_MODEL_LIST[tag_or_url]
         output_path = f"{download_dir}/{tag_or_url}.tar.gz"
+        tag = tag_or_url
     else:
         # get google drive id from the url link
+        assert "drive.google.com" in tag_or_url, "Unknown URL format. Please use google drive for the model"
         p = re.compile(r"/[-\w]{25,}")
         id_ = p.findall(tag_or_url)[0][1:]
-        tag_or_url = id_
+        tag = id_
         output_path = f"{download_dir}/{id_}.tar.gz"
 
     os.makedirs(f"{download_dir}", exist_ok=True)
@@ -396,7 +401,7 @@ def download_pretrained_model(tag_or_url, download_dir=None):
                 for member in tar.getmembers():
                     if member.isreg():
                         member.name = os.path.basename(member.name)
-                        tar.extract(member, f"{download_dir}/{tag_or_url}")
-    checkpoint_path = find_files(f"{download_dir}/{tag_or_url}", "checkpoint*.pkl")
+                        tar.extract(member, f"{download_dir}/{tag}")
+    checkpoint_path = find_files(f"{download_dir}/{tag}", "checkpoint*.pkl")
 
     return checkpoint_path[0]

--- a/parallel_wavegan/utils/utils.py
+++ b/parallel_wavegan/utils/utils.py
@@ -8,8 +8,8 @@
 import fnmatch
 import logging
 import os
-import sys
 import re
+import sys
 import tarfile
 
 from distutils.version import LooseVersion


### PR DESCRIPTION
I have changed the tag to ```tag_or_url```, now we can download other models not listed in the ```PRETRAINED_MODEL_LIST``` to be able to work with ParallelWaveGAN. For now the models should be uploaded to google drive