### PR TITLE
Update to v0.5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can try the real-time end-to-end text-to-speech and singing voice synthesis 
 
 This repository is tested on Ubuntu 20.04 with a GPU Titan V.
 
-- Python 3.6+
+- Python 3.7+
 - Cuda 10.0+
 - CuDNN 7+
 - NCCL 2+ (for distributed multi-gpu training)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This repository is tested on Ubuntu 20.04 with a GPU Titan V.
 - sox (you can install via `sudo apt install sox` in ubuntu)
 
 Different cuda version should be working but not explicitly tested.  
-All of the codes are tested on Pytorch 1.4, 1.5.1, 1.7.1, 1.8.1, 1.9, 10.2 and 11.0.
+All of the codes are tested on Pytorch 1.4, 1.5.1, 1.7.1, 1.8.1, 1.9, 1.10.2, and 1.11.0.
 
 Pytorch 1.6 works but there are some issues in cpu mode (See #198).
 

--- a/parallel_wavegan/__init__.py
+++ b/parallel_wavegan/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.5.4"
+__version__ = "0.5.5"

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ from distutils.version import LooseVersion
 from setuptools import find_packages
 from setuptools import setup
 
-if LooseVersion(sys.version) < LooseVersion("3.6"):
+if LooseVersion(sys.version) < LooseVersion("3.7"):
     raise RuntimeError(
-        "parallel-wavegan requires Python>=3.6, "
+        "parallel-wavegan requires Python>=3.7, "
         "but your Python is {}".format(sys.version)
     )
 if LooseVersion(pip.__version__) < LooseVersion("19"):
@@ -69,7 +69,7 @@ extras_require = {
 dirname = os.path.dirname(__file__)
 setup(
     name="parallel_wavegan",
-    version="0.5.4",
+    version="0.5.5",
     url="http://github.com/kan-bayashi/ParallelWaveGAN",
     author="Tomoki Hayashi",
     author_email="hayashi.tomoki@g.sp.m.is.nagoya-u.ac.jp",
@@ -84,7 +84,6 @@ setup(
     extras_require=extras_require,
     entry_points=entry_points,
     classifiers=[
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Support of Python 3.6 is dropped since pytorch 1.11 does not support it.