### PR TITLE
Fix the window function error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: Integration
         run: |
           cd egs/yesno/voc1 && ./run.sh --conf conf/${{ matrix.config }}
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: artifacts-${{ matrix.config }}
@@ -132,7 +132,7 @@ jobs:
       - name: Integration
         run: |
           cd egs/yesno/voc1 && ./run.sh --use_fake_segments true
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: artifacts-${{ matrix.config }}
@@ -173,7 +173,7 @@ jobs:
       - name: Integration
         run: |
           cd egs/yesno/vq1 && ./run.sh --conf conf/${{ matrix.config }}
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: artifacts-${{ matrix.config }}

--- a/parallel_wavegan/layers/pqmf.py
+++ b/parallel_wavegan/layers/pqmf.py
@@ -8,7 +8,7 @@
 import numpy as np
 import torch
 import torch.nn.functional as F
-from scipy.signal import kaiser
+from scipy.signal.windows import kaiser
 
 
 def design_prototype_filter(taps=62, cutoff_ratio=0.142, beta=9.0):


### PR DESCRIPTION
As mentioned in #430 , the scipy has deprecated the old interface from 1.0.0. 

Trying to submit a quick workaround to fix it for the ESPnet colab demonstration. 

Additionally, fix a version update for the github action to replace the deprecated ones.